### PR TITLE
fix: drop invalid build-base from snapcraft

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,8 +20,6 @@ architectures:
 
 confinement: strict
 base: core22
-# The base that the builds run on - allows building for other architectures
-build-base: core22
 compression: xz
 contact: https://github.com/lengau/codespell-snap/issues
 issues:


### PR DESCRIPTION
## Summary
- Remove the redundant `build-base: core22` from `snap/snapcraft.yaml`.
- Keep the existing shorthand `architectures` list unchanged.
- Snapcraft 8.14 rejects a core-style `build-base` when `base: core22` is also present, before Launchpad remote-build starts.

## Failure
- https://github.com/snapcrafters/codespell/actions/runs/27068272030/job/79892839568
- Failing line: `cannot specify a core 'build-base' alongside a 'base'`

## Verification
- `git diff --check`
- Parsed `snap/snapcraft.yaml` with Python YAML and asserted `base == core22`, no `build-base` key, and the existing shorthand architecture list is retained.
- `snapcraft expand-extensions` with Snapcraft 8.14.5 and asserted the selected expanded build plan has `base == core22`, no `build-base` key, and amd64 build-on/build-for.
- `snapcraft pack --use-lxd --verbosity=brief` completed successfully and created `codespell_2.4.2_amd64.snap`.
- Installed the locally built snap with `sudo snap install --dangerous ./codespell_2.4.2_amd64.snap` and verified runtime behaviour:
  - `codespell --version` -> `2.4.2`
  - `codespell /home/jon/codespell-runtime-test.txt` reported `adn ==> and` and exited 65 as expected.

@jnsgruk please review.
