### PR TITLE
chore: migrate snap to core24

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,16 +10,16 @@ description: |
   Therefore it should catch errors like "adn", but it will not catch "adnasdfasdf".
   This also means it shouldn't generate false-positives when you use a niche term it doesn't know about.
 
-architectures:
-  - amd64
-  - arm64
-  - armhf
-  - ppc64el
-  - riscv64
-  - s390x
+platforms:
+  amd64:
+  arm64:
+  armhf:
+  ppc64el:
+  riscv64:
+  s390x:
 
 confinement: strict
-base: core22
+base: core24
 compression: xz
 contact: https://github.com/lengau/codespell-snap/issues
 issues:


### PR DESCRIPTION
## Summary
- Migrate the snap base from `core22` to `core24`.
- Replace the legacy flat `architectures` list with a core24 `platforms` map.
- Preserve the current published architecture set: amd64, arm64, armhf, ppc64el, riscv64, s390x.

## Migration checks
- Confirmed `platforms` matches the architectures currently published for latest/stable and latest/candidate in the Snap Store channel map.
- Checked there are no `stage-packages`, so there is no Noble package-set churn to resolve for this recipe.
- Confirmed there is no stale `architectures` or `build-base` key left in `snap/snapcraft.yaml`.

## Local verification
- `git diff --check`
- Python YAML assertions for `base: core24`, `platforms`, no `architectures`, no `build-base`, and no stage-package migration needed.
- `snapcraft expand-extensions` with Snapcraft 8.14.5.
- `snapcraft clean`
- `snapcraft pack --use-lxd --verbosity=brief`, which launched a managed Ubuntu 24.04 build instance and created `codespell_2.4.2_amd64.snap`.
- Installed the locally built snap with `sudo snap install --dangerous ./codespell_2.4.2_amd64.snap` and verified runtime behaviour:
  - `codespell --version` -> `2.4.2`
  - `codespell /home/jon/codespell-core24-runtime-test.txt` reported `adn ==> and` and exited 65 as expected.
- Removed the local snap install and auto snapshot after testing.

@jnsgruk please review.
