### PR TITLE
fix: make architecture matrix explicit

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,11 +12,23 @@ description: |
 
 platforms:
   amd64:
+    build-on: [amd64]
+    build-for: [amd64]
   arm64:
+    build-on: [arm64]
+    build-for: [arm64]
   armhf:
+    build-on: [armhf]
+    build-for: [armhf]
   ppc64el:
+    build-on: [ppc64el]
+    build-for: [ppc64el]
   riscv64:
+    build-on: [riscv64]
+    build-for: [riscv64]
   s390x:
+    build-on: [s390x]
+    build-for: [s390x]
 
 confinement: strict
 base: core24


### PR DESCRIPTION
## Summary
- expand the core24 platforms block into an explicit build-on/build-for matrix
- keep the matrix aligned with currently published Snap Store architectures for codespell

## Verification
- git diff --check
- queried Snap Store v2 channel-map for latest stable/candidate architectures: amd64, arm64, armhf, ppc64el, riscv64, s390x
- parsed snap/snapcraft.yaml and asserted platforms match the Store architecture set
- snapcraft expand-extensions