### PR TITLE
docs: update workflow badge links [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![codespell](https://snapcraft.io/codespell/badge.svg)](https://snapcraft.io/codespell)
 [![codespell](https://snapcraft.io/codespell/trending.svg?name=0)](https://snapcraft.io/codespell)
-[![Release](https://github.com/snapcrafters/codespell/actions/workflows/release-to-candidate.yaml/badge.svg)](https://github.com/snapcrafters/codespell/actions/workflows/release-to-candidate.yaml)
+[![Release](https://github.com/snapcrafters/codespell/actions/workflows/release-to-candidate.yml/badge.svg)](https://github.com/snapcrafters/codespell/actions/workflows/release-to-candidate.yml)
 
 # codespell snap
 


### PR DESCRIPTION
## Summary
- Updates README workflow badge links to point at the canonical renamed workflow files.
- Keeps badge href and image URLs aligned with the standard `.yml` workflow filenames.

## Files
- `README.md`

## Replacements
- `release-to-candidate.yaml -> release-to-candidate.yml`

## Verification
- `git diff --check`
- Commit message includes `[skip ci]`.

@jnsgruk please review.
